### PR TITLE
Fix premature trace reset

### DIFF
--- a/lib/tracers.js
+++ b/lib/tracers.js
@@ -77,7 +77,7 @@
    */
   EndAnnotationTracer = function (sendTracesCallback) {
     var self = this;
-    self.annotationsForTrace = {};
+    self.annotationsForSpan = {};
     self.sendTraces = sendTracesCallback;
   };
 
@@ -88,7 +88,7 @@
    * @param {Array} traces Array of [trace, annotations] tuples.
    */
   EndAnnotationTracer.prototype.record = function (traces) {
-    var self = this, completedTraces = {};
+    var self = this;
 
     traces.forEach(function(tuple) {
       var trace, annotations, readyToGo;
@@ -96,24 +96,19 @@
       trace = tuple[0];
       annotations = tuple[1];
 
-      if (!has(self.annotationsForTrace, trace.traceId)) {
-        self.annotationsForTrace[trace.traceId] = {};
+      if (!has(self.annotationsForSpan, trace.spanId)) {
+        self.annotationsForSpan[trace.spanId] = [];
       }
 
-      if (!has(self.annotationsForTrace[trace.traceId], trace.spanId)) {
-        self.annotationsForTrace[trace.traceId][trace.spanId] = [];
-      }
-
-      self.annotationsForTrace[trace.traceId][trace.spanId] = self.annotationsForTrace[trace.traceId][trace.spanId].concat(annotations);
+      self.annotationsForSpan[trace.spanId] = self.annotationsForSpan[trace.spanId].concat(annotations);
 
       annotations.forEach(function(annotation) {
         // if it's an end annotation - ship it
         if (annotation.name === zipkinCore_types.CLIENT_RECV ||
             annotation.name === zipkinCore_types.SERVER_SEND) {
-          readyToGo = self.annotationsForTrace[trace.traceId][trace.spanId];
+          readyToGo = self.annotationsForSpan[trace.spanId];
 
-          completedTraces[trace.traceId] = 1;
-          self.annotationsForTrace[trace.traceId][trace.spanId] = [];
+          delete self.annotationsForSpan[trace.spanId];
 
           // Should probably log a message with trace and annotations here
           if (self.sendTraces !== undefined) {
@@ -121,11 +116,6 @@
           }
         }
       });
-
-      if (has(self.annotationsForTrace, trace.traceId) && has(completedTraces, trace.traceId)) {
-        delete self.annotationsForTrace[trace.traceId];
-        delete completedTraces[trace.traceId];
-      }
     });
   };
 

--- a/tests/test_tracers.js
+++ b/tests/test_tracers.js
@@ -118,6 +118,32 @@ module.exports = {
                          [trace.Annotation.serverSend(2)]]]);
       test.equal(self.sent_traces.length, 2);
       test.done();
+    },
+
+    test_record_for_child_spans: function(test) {
+      var self = this;
+      var span = new trace.Trace('server')
+      self.tracer.record([[span,
+                         [trace.Annotation.serverRecv(2)]]]);
+      self.tracer.record([[span,
+                         [trace.Annotation.string("http.uri", "/test", 2)]]]);
+
+      var child = span.child("upstream");
+      self.tracer.record([[child,
+                         [trace.Annotation.string("http.uri", "/internal/test", 2)]]]);
+      self.tracer.record([[child,
+                         [trace.Annotation.clientSend(2)]]]);
+      self.tracer.record([[child,
+                         [trace.Annotation.clientRecv(2)]]]);
+
+      self.tracer.record([[span,
+                         [trace.Annotation.serverSend(2)]]]);
+
+      test.equal(self.sent_traces.length, 2);
+      // Check that we end up with 3 annotations for each span
+      test.equal(self.sent_traces[0][0][1].length, 3);
+      test.equal(self.sent_traces[1][0][1].length, 3);
+      test.done();
     }
   }
 };


### PR DESCRIPTION
If a child span finished (such as a client request happening inside of a
server request trace) the whole trace was being cleared. Thus, when the
parent span finally finished, all of the previous annotations were lost.

Instead, track annotations only by spanId and don't reset the whole
trace when a span finishes.

Test included which demonstrates the failure.
