### PR TITLE
fix RawZipkinTracer when traces.length > 10

### DIFF
--- a/lib/node_tracers.js
+++ b/lib/node_tracers.js
@@ -212,13 +212,13 @@ function RawZipkinTracer(scribeClient, category) {
 
 util.inherits(RawZipkinTracer, EndAnnotationTracer);
 
-RawZipkinTracer.prototype._sendTrace = function(tuple) {
+RawZipkinTracer.prototype._sendTrace = function(tuple, callback) {
   var trace = tuple[0], annotations = tuple[1];
 
   async.waterfall([
     formatters.formatForZipkin.bind(null, trace, annotations),
-    this.scribeClient.send.bind(this.scribeClient, this.category)
-  ], function(err) {});
+    this.scribeClient.send.bind(this.scribeClient, this.category),
+  ], callback);
 };
 
 RawZipkinTracer.prototype.sendTraces = function(traces) {


### PR DESCRIPTION
I noticed in my testing that using node-tryfer with RawZipkinTracer
directly worked, but using ZipkinTracer with the buffering casued traces
to go missing. After some digging I discovered that
RawZipkinTracer.sendTraces is doing:

```
async.forEachLimit(traces, 10, this._sendTrace.bind(this),
                  callback);
```

The problem is that the _sendTrace method wasn't accepting a callback,
so if there are more than 10 traces they just get stuck in limbo
forever. This patch fixes _sendTrace to use the callback that is sent to
it.
