### PR TITLE
use node-microtime module for timestamps

### DIFF
--- a/lib/trace.js
+++ b/lib/trace.js
@@ -16,7 +16,7 @@
   var tracers, formatters, zipkinCore_types;
   var Trace, Annotation, Endpoint;
   var largestRandom = Math.pow(2, 53) - 1;
-  var forEach, has, getUniqueId, intOrNone;
+  var forEach, has, getUniqueId, intOrNone, getNowMicros;
 
   forEach = function(obj, f){
     Array.prototype.forEach.call(obj, f);
@@ -40,6 +40,11 @@
       return number;
     }
   };
+
+  // Return the current unix epoch timestamp in microseconds
+  getNowMicros = function() {
+      return Date.now() * 1000;
+  }
 
   /**
    * A Trace encapsulates information about the current span of this trace
@@ -304,7 +309,7 @@
    */
   Annotation.timestamp = function (name, timestamp) {
     if (timestamp === undefined) {
-      timestamp = Date.now() * 1000;
+      timestamp = getNowMicros();
     }
     return new Annotation(name, timestamp, 'timestamp');
   };
@@ -372,12 +377,24 @@
 
 
   if (typeof module !== 'undefined' && module.exports) {
+    try {
+      var microtime = require('microtime')
+      getNowMicros = function() {
+          return microtime.now()
+      }
+    } catch (err) {
+      // Use default implementation if microtime unavailable
+    }
     tracers = require('./tracers');
     formatters = require('./formatters');
     zipkinCore_types = require('./_thrift/zipkinCore/zipkinCore_types');
     exports.Trace = Trace;
     exports.Endpoint = Endpoint;
     exports.Annotation = Annotation;
+    // Exported only for tests
+    exports._overrideGetNowMicros = function(func) {
+      getNowMicros = func
+    }
   } else {
     this.Trace = Trace;
     this.Endpoint = Endpoint;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "optionalDependencies": {
     "keystone-client": ">= 0.3.0",
+    "microtime": "0.5.1",
     "scribe": ""
   },
   "engines": {

--- a/tests/test_trace.js
+++ b/tests/test_trace.js
@@ -226,16 +226,9 @@ module.exports = {
   },
   annotationTests: {
     setUp: function(cb){
-      var self = this;
-      self.origDate = Date.now;
-      Date.now = function() {
-        return 1000;
-      };
-      cb();
-    },
-    tearDown: function(cb){
-      var self = this;
-      Date.now = self.origDate;
+      trace._overrideGetNowMicros(function() {
+        return 1000000;
+      });
       cb();
     },
     test_timestamp: function(test) {


### PR DESCRIPTION
add node-microtime as an optionalDependency, and use it for microsecond
timestamps instead of Date.now() \* 1000. If the dependency cannot be
installed (since it is a native module) fail back to the old method.

https://github.com/wadey/node-microtime
