### PR TITLE
update microtime to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "optionalDependencies": {
     "keystone-client": ">= 0.3.0",
-    "microtime": "0.5.1",
+    "microtime": ">= 1.0.0",
     "scribe": ""
   },
   "engines": {


### PR DESCRIPTION
Version 0.5.1 won't work in Node 0.11+, so update it before people notice and run into errors.
