### PR TITLE
correct syntax for node engines line

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "scribe": ""
   },
   "engines": {
-    "node": ">= 0.6.0 && < 0.11"
+    "node": ">= 0.6.0 < 0.11"
   },
   "scripts": {
     "test": "./bin/tester",


### PR DESCRIPTION
&& is implicit, and is invalid syntax if included, producing npm WARNs for everyone who uses this module.
