### PR TITLE
Add a before_install directive to .travis.yml to update npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
 before_install:
 - '[ "${TRAVIS_NODE_VERSION}" != "0.8" ] || npm install -g npm@1.4.28'
 - '[ "${TRAVIS_NODE_VERSION}" != "0.6" ] || npm install -g npm@1.3.26'
-- npm install -g npm@latest
+- '[ "${TRAVIS_NODE_VERSION}" != "0.1*" ] || npm install -g npm@latest'
 
 before_script: npm run-script lint
 script: npm test


### PR DESCRIPTION
Travis has been failing for Node 0.6 and 0.8 (see https://github.com/npm/npm/issues/4849 and https://github.com/npm/npm/issues/5906)

As per the directions, adding the directive given [here](https://github.com/npm/npm/wiki/Troubleshooting#travis-projects-using-08-cant-upgrade-to-npm-2) to update NPM on travis.

While 0.6 is no longer supported by NPM, NPM version 1.3.26 seems to handle both carets (`^`) and tildes (`~`).

This should fix travis breakage.
