### PR TITLE
work around IPv6 addresses in Trace#fromRequest

### DIFF
--- a/lib/trace.js
+++ b/lib/trace.js
@@ -15,7 +15,7 @@
 (function () {
   var tracers, formatters, zipkinCore_types;
   var Trace, Annotation, Endpoint, Int64;
-  var forEach, has, getUniqueId, getNowMicros, getHex64;
+  var forEach, has, getUniqueId, getNowMicros, getHex64, isIPv4;
 
   forEach = function(obj, f){
     Array.prototype.forEach.call(obj, f);
@@ -53,6 +53,28 @@
   getNowMicros = function() {
       return Date.now() * 1000;
   };
+
+  /**
+   * Returns true if an IP address is v4 dotted decimal
+   * @param {String} address
+   * @returns {Boolean}
+   */
+  isIPv4 = function(address) {
+    var octets = address.split('.');
+
+    if (octets.length !== 4) {
+      return false;
+    }
+
+    forEach(octets, function(octet) {
+      var n = parseInt(octet)
+      if (isNaN(n) || n < 0 || n > 255) {
+        return false;
+      }
+    });
+
+    return true;
+  }
 
   /**
    * A Trace encapsulates information about the current span of this trace
@@ -237,6 +259,11 @@
 
     var host = (request.socket && request.socket.address ?
       request.socket.address() : {address: '127.0.0.1', port: 80});
+    if (host.address === '::1') {
+      host.address = '127.0.0.1'
+    } else if (!isIPv4(host.address)) {
+      host.address = '0.0.0.0';
+    }
 
     if (serviceName === undefined || serviceName === null) {
       serviceName = 'http';

--- a/tests/test_trace.js
+++ b/tests/test_trace.js
@@ -223,6 +223,34 @@ module.exports = {
         {method: 'GET', headers: {}}, 'this_is_a_service');
       test.equal(t.endpoint.serviceName, "this_is_a_service");
       test.done();
+    },
+    test_fromRequest_endpoint_with_ipv6_localhost: function(test) {
+      var t = new trace.Trace.fromRequest({
+        method: 'GET',
+        headers: {},
+        socket: {
+          address: function() {
+            return {family: 2, port: 8888, address: '::1'};
+          }
+        }
+      });
+      test.equal(t.endpoint.ipv4, '127.0.0.1');
+      test.equal(t.endpoint.port, 8888);
+      test.done();
+    },
+    test_fromRequest_endpoint_with_other_ipv6: function(test) {
+      var t = new trace.Trace.fromRequest({
+        method: 'GET',
+        headers: {},
+        socket: {
+          address: function() {
+            return {family: 2, port: 8888, address: '2001:db8::ff00:42:8329'};
+          }
+        }
+      });
+      test.equal(t.endpoint.ipv4, '0.0.0.0');
+      test.equal(t.endpoint.port, 8888);
+      test.done();
     }
   },
   annotationTests: {


### PR DESCRIPTION
When tracing systems on IPv6 networks, transmission to the collector fails.

```
error:  Error: IPv4 string does not have 4 parts.
    at ipv4ToNumber (.../node_modules/tryfer/lib/formatters.js:123:13)
    at .../node_modules/tryfer/lib/formatters.js:157:17
    at Array.forEach (native)
    at Object.formatForZipkin (.../node_modules/tryfer/lib/formatters.js:153:29)
    at RawZipkinTracer._sendTrace (.../node_modules/tryfer/lib/node_tracers.js:219:14)
    at replenish (.../node_modules/tryfer/node_modules/async/lib/async.js:144:17)
    at Object.async.forEachLimit (.../node_modules/tryfer/node_modules/async/lib/async.js:161:11)
    at RawZipkinTracer.sendTraces (.../node_modules/tryfer/lib/node_tracers.js:230:9)
    at BufferingTracer._sendTraces (.../node_modules/tryfer/lib/node_tracers.js:100:16)
    at BufferingTracer._periodicSendFunction (.../node_modules/tryfer/lib/node_tracers.js:90:10)
    at Timer.listOnTimeout (timers.js:119:15)
```

Zipkin's Thrift schema doesn't accommodate IPv6 addresses, so the only way to deal with them is to mask them.