### PR TITLE
Add support for X-B3-Sampled header and sampled flag in Trace object

### DIFF
--- a/lib/trace.js
+++ b/lib/trace.js
@@ -250,9 +250,9 @@
       }
     });
 
-    if (headers['x-b3-sampled'] === '0'){
+    if (headers['x-b3-sampled'] === '0' || headers['x-b3-sampled'] === "false"){
       traceOptions['sampled'] = false;
-    } else if (headers['x-b3-sampled'] === '1'){
+    } else if (headers['x-b3-sampled'] === '1' || headers['x-b3-sampled'] === "true"){
       traceOptions['sampled'] = true;
     } else {
       traceOptions['sampled'] = sampled !== false;

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -280,9 +280,9 @@
    * @param {Boolean} sampled - set to false if trace should NOT be sampled 
    *    defaults to true
    */
-  Trace.fromRequest = function(request, serviceName, sample) {
+  Trace.fromRequest = function(request, serviceName, sampled) {
     var newTrace = Trace.fromHeaders(
-      request.method || 'GET', request.headers || {}, sample);
+      request.method || 'GET', request.headers || {}, sampled);
 
     var host = (request.socket && request.socket.address ?
       request.socket.address() : { address: '127.0.0.1', port: 80 });

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -236,7 +236,7 @@
    * @param {Boolean} sampled Indicates local sampling decision. Inbound
    *     X-B3-Sampled headers take precedence and will be honoured if present
    */
-   Trace.fromHeaders = function(traceName, headers, sampled) {
+  Trace.fromHeaders = function(traceName, headers, sampled) {
     var traceOptions = {};
 
     ['X-B3-TraceId', 'X-B3-SpanId', 'X-B3-ParentSpanId'].forEach(function(v) {

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -209,7 +209,11 @@
     if (self.parentSpanId !== undefined) {
       headers['X-B3-ParentSpanId'] = self.parentSpanId;
     }
-    headers['X-B3-Sampled'] = self.sampled;
+    if (self.sampled){
+        headers['X-B3-Sampled'] = 1;
+    } else {
+        headers['X-B3-Sampled'] = 0;
+    }
     return headers;
   };
 
@@ -246,9 +250,9 @@
       }
     });
 
-    if (headers['x-b3-sampled'] === false){
+    if (headers['x-b3-sampled'] === '0'){
       traceOptions['sampled'] = false;
-    } else if (headers['x-b3-sampled'] === true){
+    } else if (headers['x-b3-sampled'] === '1'){
       traceOptions['sampled'] = true;
     } else {
       traceOptions['sampled'] = sampled !== false;

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -90,6 +90,8 @@
    * @param {Number} options.spanId 64-bit integer identifying this span
    * @param {Number} options.parentSpanId 64-bit integer identifying this trace's
    *     parent span, or undefined.
+   * @param {Boolean} options.sampled false if this trace should NOT be sampled
+   *     default behaviour is to be sampled
    * @param {Array} options._tracers Zero or more {Tracers}
    */
   Trace = function(name, options) {
@@ -116,6 +118,12 @@
     } else {
       self._tracers = tracers.getTracers();
     }
+
+    if (has(options, 'sampled')){
+        this.sampled = (options.sampled === true);
+    } else {
+      this.sampled = true;
+    }
   };
 
   /**
@@ -134,6 +142,7 @@
       traceId: this.traceId,
       parentSpanId: this.spanId,
       debug: this.debug,
+      sampled : this.sampled,
       tracers: this._tracers
     };
     var trace = new Trace(name, optionalArgs);
@@ -155,9 +164,11 @@
       annotation.endpoint = this.endpoint;
     }
 
-    forEach(this._tracers, function(tracer) {
-      tracer.record([[self, [annotation]]]);
-    });
+    if (this.sampled){
+      forEach(this._tracers, function(tracer) {
+        tracer.record([[self, [annotation]]]);
+      });
+    }
   };
 
   /**
@@ -181,9 +192,8 @@
    *
    * https://github.com/twitter/finagle/blob/master/finagle-http/
    *
-   * Currently not implemented are X-B3-Sampled and X-B3-Flags.
-   * Tryfer's underlying Trace implementation has no notion of a Sampled
-   * trace, and also does not support flags.
+   * Currently not implemented is X-B3-Flags.
+   * Tryfer's underlying Trace implementation does not support flags
    *
    * @param {Object} headers Optional.  The headers to add tracing headers to.
    *    If not provided, will use a new empty hash.  Either way, will return
@@ -199,6 +209,7 @@
     if (self.parentSpanId !== undefined) {
       headers['X-B3-ParentSpanId'] = self.parentSpanId;
     }
+    headers['X-B3-Sampled'] = self.sampled;
     return headers;
   };
 
@@ -209,9 +220,8 @@
    * These headers are based on the headers used by finagle's tracing
    * http Codec.
    *
-   * Currently not implemented are X-B3-Sampled and X-B3-Flags.
-   * Tryfer's underlying Trace implementation has no notion of a Sampled
-   * trace, and also does not support flags.
+   * Currently not implemented is X-B3-Flags.
+   * Tryfer's underlying Trace implementation does not support flags
    *
    * ASSUMPTION: header names are all lower cased
    *    The default behavior of the NodeJS http module is to lower-case all
@@ -223,8 +233,10 @@
    *    match with tryfer's naming convention
    * @param {Object} headers A mapping of lower-cased header field names to
    *    values
+   * @param {Boolean} sampled Indicates local sampling decision. Inbound
+   *     X-B3-Sampled headers take precedence and will be honoured if present
    */
-  Trace.fromHeaders = function(traceName, headers) {
+   Trace.fromHeaders = function(traceName, headers, sampled) {
     var traceOptions = {};
 
     ['X-B3-TraceId', 'X-B3-SpanId', 'X-B3-ParentSpanId'].forEach(function(v) {
@@ -233,6 +245,14 @@
         traceOptions[v.slice(5,6).toLowerCase() + v.slice(6)] = processed;
       }
     });
+
+    if (headers['x-b3-sampled'] === false){
+      traceOptions['sampled'] = false;
+    } else if (headers['x-b3-sampled'] === true){
+      traceOptions['sampled'] = true;
+    } else {
+      traceOptions['sampled'] = sampled !== false;
+    }
 
     return new Trace(traceName, traceOptions);
   };
@@ -257,10 +277,12 @@
    *
    * @param {Object} request The request object
    * @param {String} serviceName The name of the service) - defaults to 'http'
+   * @param {Boolean} sampled - set to false if trace should NOT be sampled 
+   *    defaults to true
    */
-  Trace.fromRequest = function(request, serviceName) {
+  Trace.fromRequest = function(request, serviceName, sample) {
     var newTrace = Trace.fromHeaders(
-      request.method || 'GET', request.headers || {});
+      request.method || 'GET', request.headers || {}, sample);
 
     var host = (request.socket && request.socket.address ?
       request.socket.address() : { address: '127.0.0.1', port: 80 });

--- a/tests/test_trace.js
+++ b/tests/test_trace.js
@@ -123,6 +123,18 @@ module.exports = {
       test.deepEqual(tracer._calls.record[0], [[[t, [a]]]]);
       test.done();
     },
+    test_record_does_not_invoke_tracer_when_not_sampled: function(test){
+      var tracer, t, a;
+      tracer = new mockTracer();
+      t = new trace.Trace('test_trace', {
+          traceId: 1, spanId: 1, tracers: [tracer], sampled: false
+      });
+      a = trace.Annotation.clientSend(0);
+      t.record(a);
+
+      test.equal(tracer._calls.record.length, 0);
+      test.done();
+    },
     test_record_sets_annotation_endpoint: function(test){
       var tracer, e, t, a;
       tracer = new mockTracer();
@@ -140,7 +152,8 @@ module.exports = {
       var t = new trace.Trace('GET', {traceId: 1, spanId: 10});
       test.deepEqual(t.toHeaders(), {
         'X-B3-TraceId': '0000000000000001',
-        'X-B3-SpanId': '000000000000000a'
+        'X-B3-SpanId': '000000000000000a',
+        'X-B3-Sampled' : true
       });
       test.done();
     },
@@ -149,7 +162,8 @@ module.exports = {
       test.deepEqual(t.toHeaders(), {
         'X-B3-TraceId': '0000000000000001',
         'X-B3-SpanId': '000000000000000a',
-        'X-B3-ParentSpanId': '0000000000000005'
+        'X-B3-ParentSpanId': '0000000000000005',
+        'X-B3-Sampled' : true
       });
       test.done();
     },
@@ -159,6 +173,7 @@ module.exports = {
       test.deepEqual(t.toHeaders(headers), {
         'X-B3-TraceId': '0000000000000001',
         'X-B3-SpanId': '000000000000000a',
+        'X-B3-Sampled' : true, 
         'Content-Type': 'application/json'
       });
       test.done();
@@ -198,6 +213,20 @@ module.exports = {
       test.equal(t.parentSpanId, formatters._hexStringify(5));
       test.done();
     },
+    test_fromHeaders_with_sampled: function(test) {
+      var t = trace.Trace.fromHeaders('POST',
+        {
+          'x-b3-traceid': '0000000000000001',
+          'x-b3-spanid': '000000000000000a',
+          'x-b3-sampled': false
+        });
+
+      test.equal(t.name, 'POST');
+      test.equal(t.traceId, formatters._hexStringify(1));
+      test.equal(t.spanId, formatters._hexStringify(10));
+      test.equal(t.sampled, false);
+      test.done();
+    },
     test_fromRequest_calls_fromHeaders: function(test) {
       var orig = trace.Trace.fromHeaders;
       var test_headers = {'hat': 'cat'};
@@ -213,6 +242,52 @@ module.exports = {
       };
       trace.Trace.fromRequest({method: 'POST', headers: test_headers});
       test.done();
+    },
+    test_fromRequest_defaults_sampled_behaviour_to_sampled : function(test){
+        var request = {
+            'headers' : {
+               'x-b3-traceid': '0000000000000001',
+               'x-b3-spanid': '000000000000000a'
+            }
+        };
+        var t = trace.Trace.fromRequest(request, 'test');
+        test.equal(t.sampled, true);
+        test.done();
+    },
+    test_fromRequest_honours_inbound_dont_sample_header_over_local_do_sample_indicator : function(test){
+        var request = {
+            'headers' : {
+               'x-b3-traceid': '0000000000000001',
+               'x-b3-spanid': '000000000000000a',
+               'x-b3-sampled': false
+            }
+        };
+        var t = trace.Trace.fromRequest(request, 'test', true);
+        test.equal(t.sampled, false);
+        test.done();
+    },
+    test_fromRequest_honours_inbound_do_sample_header_over_local_dont_sample_indicator : function(test){
+        var request = {
+            'headers' : {
+               'x-b3-traceid': '0000000000000001',
+               'x-b3-spanid': '000000000000000a',
+               'x-b3-sampled': true
+            }
+        };
+        var t = trace.Trace.fromRequest(request, 'test', false);
+        test.equal(t.sampled, true);
+        test.done();
+    },
+    test_fromRequest_honours_local_sampled_indicator_in_the_absence_of_an_inbound_sampled_header : function(test){
+        var request = {
+            'headers' : {
+               'x-b3-traceid': '0000000000000001',
+               'x-b3-spanid': '000000000000000a'
+            }
+        };
+        var t = trace.Trace.fromRequest(request, 'test', false);
+        test.equal(t.sampled, false);
+        test.done();
     },
     test_fromRequest_default_endpoint: function(test) {
       var t = trace.Trace.fromRequest({method: 'GET', headers: {}});

--- a/tests/test_trace.js
+++ b/tests/test_trace.js
@@ -254,7 +254,7 @@ module.exports = {
         test.equal(t.sampled, true);
         test.done();
     },
-    test_fromRequest_honours_inbound_dont_sample_header_over_local_do_sample_indicator : function(test){
+    test_fromRequest_honours_inbound_dont_sample_header_as_binary_over_local_do_sample_indicator : function(test){
         var request = {
             'headers' : {
                'x-b3-traceid': '0000000000000001',
@@ -266,12 +266,36 @@ module.exports = {
         test.equal(t.sampled, false);
         test.done();
     },
-    test_fromRequest_honours_inbound_do_sample_header_over_local_dont_sample_indicator : function(test){
+    test_fromRequest_honours_inbound_dont_sample_header_as_boolean_over_local_do_sample_indicator : function(test){
+        var request = {
+            'headers' : {
+               'x-b3-traceid': '0000000000000001',
+               'x-b3-spanid': '000000000000000a',
+               'x-b3-sampled': 'false'
+            }
+        };
+        var t = trace.Trace.fromRequest(request, 'test', true);
+        test.equal(t.sampled, false);
+        test.done();
+    },
+    test_fromRequest_honours_inbound_do_sample_header_as_binary_over_local_dont_sample_indicator : function(test){
         var request = {
             'headers' : {
                'x-b3-traceid': '0000000000000001',
                'x-b3-spanid': '000000000000000a',
                'x-b3-sampled': '1'
+            }
+        };
+        var t = trace.Trace.fromRequest(request, 'test', false);
+        test.equal(t.sampled, true);
+        test.done();
+    },
+    test_fromRequest_honours_inbound_do_sample_header_as_boolean_over_local_dont_sample_indicator : function(test){
+        var request = {
+            'headers' : {
+               'x-b3-traceid': '0000000000000001',
+               'x-b3-spanid': '000000000000000a',
+               'x-b3-sampled': 'true'
             }
         };
         var t = trace.Trace.fromRequest(request, 'test', false);

--- a/tests/test_trace.js
+++ b/tests/test_trace.js
@@ -173,7 +173,7 @@ module.exports = {
       test.deepEqual(t.toHeaders(headers), {
         'X-B3-TraceId': '0000000000000001',
         'X-B3-SpanId': '000000000000000a',
-        'X-B3-Sampled' : true, 
+        'X-B3-Sampled' : true,
         'Content-Type': 'application/json'
       });
       test.done();

--- a/tests/test_trace.js
+++ b/tests/test_trace.js
@@ -153,7 +153,7 @@ module.exports = {
       test.deepEqual(t.toHeaders(), {
         'X-B3-TraceId': '0000000000000001',
         'X-B3-SpanId': '000000000000000a',
-        'X-B3-Sampled' : true
+        'X-B3-Sampled' : '1'
       });
       test.done();
     },
@@ -163,7 +163,7 @@ module.exports = {
         'X-B3-TraceId': '0000000000000001',
         'X-B3-SpanId': '000000000000000a',
         'X-B3-ParentSpanId': '0000000000000005',
-        'X-B3-Sampled' : true
+        'X-B3-Sampled' : '1'
       });
       test.done();
     },
@@ -173,7 +173,7 @@ module.exports = {
       test.deepEqual(t.toHeaders(headers), {
         'X-B3-TraceId': '0000000000000001',
         'X-B3-SpanId': '000000000000000a',
-        'X-B3-Sampled' : true,
+        'X-B3-Sampled' : '1',
         'Content-Type': 'application/json'
       });
       test.done();
@@ -218,7 +218,7 @@ module.exports = {
         {
           'x-b3-traceid': '0000000000000001',
           'x-b3-spanid': '000000000000000a',
-          'x-b3-sampled': false
+          'x-b3-sampled': '0'
         });
 
       test.equal(t.name, 'POST');
@@ -259,7 +259,7 @@ module.exports = {
             'headers' : {
                'x-b3-traceid': '0000000000000001',
                'x-b3-spanid': '000000000000000a',
-               'x-b3-sampled': false
+               'x-b3-sampled': '0'
             }
         };
         var t = trace.Trace.fromRequest(request, 'test', true);
@@ -271,7 +271,7 @@ module.exports = {
             'headers' : {
                'x-b3-traceid': '0000000000000001',
                'x-b3-spanid': '000000000000000a',
-               'x-b3-sampled': true
+               'x-b3-sampled': '1'
             }
         };
         var t = trace.Trace.fromRequest(request, 'test', false);


### PR DESCRIPTION
The current absence of support for sampled headers means that a sampling decision at the edge of a suite of services is not honoured on downstream systems. 

This pull request addresses that issue and ensures that the holistic sampling decision for the current node (be it inherited from upstream request headers, or made locally) is also made available in the trace headers, so they can be attached to any downstream request